### PR TITLE
feat: add configurable server port via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ POSTGRES_DB=cpab
 # Application Configuration
 JWT_SECRET=change-this-secret-string
 JWT_EXPIRY=720h
+
+# Server Configuration
+SERVER_PORT=8318

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-cpab} -d ${POSTGRES_DB:-cpab}"]
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${POSTGRES_USER:-cpab} -d ${POSTGRES_DB:-cpab}
       interval: 5s
       timeout: 5s
       retries: 5
@@ -32,6 +34,6 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "8318:8318"
+      - "${SERVER_PORT:-8318}:8318"
     working_dir: /CLIProxyAPIBusiness
     command: ./cpab


### PR DESCRIPTION
## Summary
- Add `SERVER_PORT` environment variable to `.env.example` for documentation
- Update `docker-compose.yml` to use `${SERVER_PORT:-8318}` for host port mapping, enabling flexible deployment across different environments
- Standardize healthcheck test format to native YAML list syntax for better readability

## Changes
| File | Change |
|------|--------|
| `.env.example` | Added `SERVER_PORT=8318` configuration |
| `docker-compose.yml` | Parameterized port mapping + YAML format cleanup |

## Test Plan
- [ ] Verify `docker-compose config` outputs valid configuration
- [ ] Test with default port (no `SERVER_PORT` set)
- [ ] Test with custom `SERVER_PORT` value
- [ ] Verify PostgreSQL healthcheck still works correctly